### PR TITLE
Bottom Navigation tab element

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,6 +11,9 @@
 
   <link rel="import" href="x-scrollable.html">
   <link rel="import" href="../gmd-bottom-nav.html">
+  <link rel="import" href="../gmd-bottom-nav-tab.html">
+  <link rel="import" href="/bower_components/iron-icons/iron-icons.html">
+  <link rel="import" href="/bower_components/iron-icons/maps-icons.html">
 
   <style>
     gmd-bottom-nav {
@@ -24,7 +27,11 @@
   <h3>Basic gmd-bottom-nav demo</h3>
   <x-scrollable>
   </x-scrollable>
-  <gmd-bottom-nav></gmd-bottom-nav>
+  <gmd-bottom-nav>
+    <gmd-bottom-nav-tab icon="history" name="recents" label="Recents"></gmd-bottom-nav-tab>
+    <gmd-bottom-nav-tab icon="favorite" name="favorites" label="Favorites"></gmd-bottom-nav-tab>
+    <gmd-bottom-nav-tab icon="maps:place" name="nearby" label="Nearby"></gmd-bottom-nav-tab>
+  </gmd-bottom-nav>
 </body>
 
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,7 +17,7 @@
 
   <style>
     gmd-bottom-nav {
-      background-color: deepskyblue;
+      background-color: white;
     }
 
   </style>
@@ -29,7 +29,7 @@
   </x-scrollable>
   <gmd-bottom-nav>
     <gmd-bottom-nav-tab icon="history" name="recents" label="Recents"></gmd-bottom-nav-tab>
-    <gmd-bottom-nav-tab icon="favorite" name="favorites" label="Favorites"></gmd-bottom-nav-tab>
+    <gmd-bottom-nav-tab class="selected" icon="favorite" name="favorites" label="Favorites"></gmd-bottom-nav-tab>
     <gmd-bottom-nav-tab icon="maps:place" name="nearby" label="Nearby"></gmd-bottom-nav-tab>
   </gmd-bottom-nav>
 </body>

--- a/gmd-bottom-nav-tab.html
+++ b/gmd-bottom-nav-tab.html
@@ -1,0 +1,62 @@
+<link rel="import" href="/bower_components/polymer/polymer-element.html">
+<link rel="import" href="/bower_components/iron-icon/iron-icon.html">
+
+<dom-module id="gmd-bottom-nav-tab">
+  <template>
+    <style>
+      :host {
+        display: block;
+        box-sizing: border-box;
+        height: 56px;
+        padding-top: 8px;
+        color: rgba(0, 0, 0, .54);
+      }
+      :host(.selected) {
+        padding-top: 6px;
+        color: black;
+      }
+    </style>
+
+   <iron-icon icon="[[icon]]"></iron-icon>
+   <div>[[label]]</div>
+
+  </template>
+
+  <script>
+    /**
+     * `gmd-bottom-nav-tab`
+     * Tab element for Google Material Design bottom navigation
+     *
+     * @customElement
+     * @polymer
+     * @demo demo/index.html
+     */
+    class GmdBottomNavTab extends Polymer.Element {
+
+      static get is() {
+        return 'gmd-bottom-nav-tab';
+      }
+
+      static get properties() {
+        return {
+          icon: {
+            type: String,
+            value: ''
+          },
+          name: {
+            type: String,
+            value: ''
+          },
+          label: {
+            type: String,
+            value: ''
+          }
+        };
+      }
+
+    }
+
+    window.customElements.define(GmdBottomNavTab.is, GmdBottomNavTab);
+
+  </script>
+</dom-module>

--- a/gmd-bottom-nav-tab.html
+++ b/gmd-bottom-nav-tab.html
@@ -27,6 +27,7 @@
         position: absolute;
         /* tab height - label offset: 56 - 10 */
         top: 46px;
+        user-select: none;
       }
       .label-offset {
         display: inline-block;

--- a/gmd-bottom-nav-tab.html
+++ b/gmd-bottom-nav-tab.html
@@ -1,24 +1,52 @@
 <link rel="import" href="/bower_components/polymer/polymer-element.html">
 <link rel="import" href="/bower_components/iron-icon/iron-icon.html">
+<link rel="import" href="/bower_components/paper-styles/typography.html">
+
 
 <dom-module id="gmd-bottom-nav-tab">
   <template>
     <style>
       :host {
-        display: block;
+        position: relative;
+        display: flex;
+        justify-content: center;
         box-sizing: border-box;
         height: 56px;
         padding-top: 8px;
-        color: rgba(0, 0, 0, .54);
+        color: rgba(0, 0, 0, .38);
+        @apply --paper-font-common-base;
+        font-size: 12px;
       }
       :host(.selected) {
         padding-top: 6px;
-        color: black;
+        color: rgba(0, 0, 0, .54);
+        font-size: 14px;
+      }
+
+      #label-container {
+        position: absolute;
+        /* tab height - label offset: 56 - 10 */
+        top: 46px;
+      }
+      .label-offset {
+        display: inline-block;
+        /* height must be greater than label text content box height */
+        height: 30px;
+      }
+      #label {
+        display: inline-block;
+        position: relative;
+        /* top must be equal to label offset height */
+        top: -30px;
       }
     </style>
 
    <iron-icon icon="[[icon]]"></iron-icon>
-   <div>[[label]]</div>
+   <div id="label-container">
+     <div class="label-offset"></div>
+     <div id="label">[[label]]</div>
+     <div class="label-offset"></div>
+   </div>
 
   </template>
 

--- a/gmd-bottom-nav-tab.html
+++ b/gmd-bottom-nav-tab.html
@@ -1,7 +1,7 @@
 <link rel="import" href="/bower_components/polymer/polymer-element.html">
 <link rel="import" href="/bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="/bower_components/paper-styles/typography.html">
-
+<link rel="import" href="/bower_components/paper-ripple/paper-ripple.html">
 
 <dom-module id="gmd-bottom-nav-tab">
   <template>
@@ -10,17 +10,24 @@
         position: relative;
         display: flex;
         justify-content: center;
+        align-items: center;
         box-sizing: border-box;
         height: 56px;
-        padding-top: 8px;
+        padding: 8px 12px 0;
         color: rgba(0, 0, 0, .38);
         @apply --paper-font-common-base;
         font-size: 12px;
+        /* This contains the ripple inside of the tab. */
+        overflow: hidden;
       }
       :host(.selected) {
         padding-top: 6px;
         color: rgba(0, 0, 0, .54);
         font-size: 14px;
+      }
+
+      iron-icon {
+        align-self: flex-start;
       }
 
       #label-container {
@@ -40,6 +47,15 @@
         /* top must be equal to label offset height */
         top: -30px;
       }
+
+      #ripple-container {
+        position: absolute;
+        width: 100%;
+        /* This ensures the container is a square. */
+        padding-top: 100%;
+        /* Create round border for ripple. */
+        border-radius: 50%;
+      }
     </style>
 
    <iron-icon icon="[[icon]]"></iron-icon>
@@ -47,6 +63,10 @@
      <div class="label-offset"></div>
      <div id="label">[[label]]</div>
      <div class="label-offset"></div>
+   </div>
+
+   <div id="ripple-container">
+     <paper-ripple></paper-ripple>
    </div>
 
   </template>

--- a/gmd-bottom-nav.html
+++ b/gmd-bottom-nav.html
@@ -25,7 +25,6 @@
       }
       ::slotted(gmd-bottom-nav-tab) {
         flex-grow: 1;
-        color: white;
       }
     </style>
 

--- a/gmd-bottom-nav.html
+++ b/gmd-bottom-nav.html
@@ -5,7 +5,7 @@
   <template>
     <style>
       :host {
-        display: block;
+        display: flex;
         height: 56px;
         position: fixed;
         bottom: 0;
@@ -23,9 +23,13 @@
         box-shadow: none;
         bottom: -56px;
       }
+      ::slotted(gmd-bottom-nav-tab) {
+        flex-grow: 1;
+        color: white;
+      }
     </style>
 
-    <h2>Hello [[prop1]]!</h2>
+    <slot></slot>
   </template>
 
   <script>
@@ -45,10 +49,6 @@
 
       static get properties() {
         return {
-          prop1: {
-            type: String,
-            value: 'gmd-bottom-nav'
-          },
           hidden: {
             type: Boolean,
             value: false,


### PR DESCRIPTION
Use a custom element that has an icon and text label to fill in the slots of <gmd-bottom-nav>.

Example:
```
<gmd-bottom-nav defaultSelectedIndex="1" selectedTabName="{{selectedTab}}">
  <gmd-bottom-nav-tab icon="edit" name="toady" label="Today"></gmd-bottom-nav-tab>
  <gmd-bottom-nav-tab icon="calendar" name="calendar" label="Calendar"></gmd-bottom-nav-tab>
  <gmd-bottom-nav-tab icon="settings" name="settings" label="Settings"></gmd-bottom-nav-tab>
</gmd-bottom-nav>
```