### PR TITLE
Bottom Navigation tab selection

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,11 @@
   "main": "gmd-bottom-nav.html",
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
-    "iron-scroll-target-behavior": "PolymerElements/iron-scroll-target-behavior#^2.0.0"
+    "iron-scroll-target-behavior": "PolymerElements/iron-scroll-target-behavior#^2.0.0",
+    "iron-icons": "PolymerElements/iron-icons#^2.0.1",
+    "iron-icon": "PolymerElements/iron-icon#^2.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^2.0.0",
+    "paper-ripple": "PolymerElements/paper-ripple#^2.0.1"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,8 @@
     "iron-icons": "PolymerElements/iron-icons#^2.0.1",
     "iron-icon": "PolymerElements/iron-icon#^2.0.0",
     "paper-styles": "PolymerElements/paper-styles#^2.0.0",
-    "paper-ripple": "PolymerElements/paper-ripple#^2.0.1"
+    "paper-ripple": "PolymerElements/paper-ripple#^2.0.1",
+    "iron-selector": "PolymerElements/iron-selector#^2.0.0"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
   <h3>Basic gmd-bottom-nav demo</h3>
   <x-scrollable>
   </x-scrollable>
-  <gmd-bottom-nav attr-for-selected="name" selected-class="selected">
+  <gmd-bottom-nav attr-for-selected="name">
     <gmd-bottom-nav-tab icon="history" name="recents" label="Recents"></gmd-bottom-nav-tab>
     <gmd-bottom-nav-tab class="selected" icon="favorite" name="favorites" label="Favorites"></gmd-bottom-nav-tab>
     <gmd-bottom-nav-tab icon="maps:place" name="nearby" label="Nearby"></gmd-bottom-nav-tab>

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
   <h3>Basic gmd-bottom-nav demo</h3>
   <x-scrollable>
   </x-scrollable>
-  <gmd-bottom-nav>
+  <gmd-bottom-nav attr-for-selected="name" selected-class="selected">
     <gmd-bottom-nav-tab icon="history" name="recents" label="Recents"></gmd-bottom-nav-tab>
     <gmd-bottom-nav-tab class="selected" icon="favorite" name="favorites" label="Favorites"></gmd-bottom-nav-tab>
     <gmd-bottom-nav-tab icon="maps:place" name="nearby" label="Nearby"></gmd-bottom-nav-tab>

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,9 +27,9 @@
   <h3>Basic gmd-bottom-nav demo</h3>
   <x-scrollable>
   </x-scrollable>
-  <gmd-bottom-nav attr-for-selected="name">
+  <gmd-bottom-nav attr-for-selected="name" fallback-selection="favorites">
     <gmd-bottom-nav-tab icon="history" name="recents" label="Recents"></gmd-bottom-nav-tab>
-    <gmd-bottom-nav-tab class="selected" icon="favorite" name="favorites" label="Favorites"></gmd-bottom-nav-tab>
+    <gmd-bottom-nav-tab icon="favorite" name="favorites" label="Favorites"></gmd-bottom-nav-tab>
     <gmd-bottom-nav-tab icon="maps:place" name="nearby" label="Nearby"></gmd-bottom-nav-tab>
   </gmd-bottom-nav>
 </body>

--- a/gmd-bottom-nav-tab.html
+++ b/gmd-bottom-nav-tab.html
@@ -92,10 +92,6 @@
             type: String,
             value: ''
           },
-          name: {
-            type: String,
-            value: ''
-          },
           label: {
             type: String,
             value: ''

--- a/gmd-bottom-nav.html
+++ b/gmd-bottom-nav.html
@@ -1,5 +1,6 @@
 <link rel="import" href="/bower_components/polymer/polymer-element.html">
 <link rel="import" href="/bower_components/iron-scroll-target-behavior/iron-scroll-target-behavior.html">
+<link rel="import" href="/bower_components/iron-selector/iron-selectable.html">
 
 <dom-module id="gmd-bottom-nav">
   <template>
@@ -40,7 +41,7 @@
      * @polymer
      * @demo demo/index.html
      */
-    class GmdBottomNav extends Polymer.mixinBehaviors([Polymer.IronScrollTargetBehavior], Polymer.Element) {
+    class GmdBottomNav extends Polymer.mixinBehaviors([Polymer.IronScrollTargetBehavior, Polymer.IronSelectableBehavior], Polymer.Element) {
 
       static get is() {
         return 'gmd-bottom-nav';

--- a/gmd-bottom-nav.html
+++ b/gmd-bottom-nav.html
@@ -53,6 +53,15 @@
             type: Boolean,
             value: false,
             reflectToAttribute: true
+          },
+
+          /* Set selectedClass to 'selected' because it's used in <gm-bottom-nav-tab> to style the selected tab.
+           * And we don't want the user to change it.
+           */
+          selectedClass: {
+            type: String,
+            value: 'selected',
+            readOnly: true
           }
         };
       }


### PR DESCRIPTION
To enable selection of the tabs, we plan to use `<iron-selector>` from _PolymerElements_.
At the same time, we need to pop the selected index and tab name to `<gmd-bottom-nav>`, so that they can be accessed to switch pages.